### PR TITLE
feat(mass_queue): only update URL on zeroconf discovery when current URL is unreachable

### DIFF
--- a/custom_components/mass_queue/config_flow.py
+++ b/custom_components/mass_queue/config_flow.py
@@ -57,6 +57,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         """Set up flow instance."""
         self.server_info: ServerInfoMessage | None = None
 
+
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
@@ -74,7 +75,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
                     raise_on_progress=False,
                 )
                 self._abort_if_unique_id_configured(
-                    updates={CONF_URL: self.server_info.base_url},
+                    updates={CONF_URL: user_input[CONF_URL]},
                     reload_on_update=True,
                 )
             except CannotConnect:
@@ -88,7 +89,7 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=DEFAULT_TITLE,
                     data={
-                        CONF_URL: self.server_info.base_url,
+                        CONF_URL: user_input[CONF_URL],
                     },
                 )
 
@@ -112,14 +113,34 @@ class MusicAssistantConfigFlow(ConfigFlow, domain=DOMAIN):
         # abort if discovery info is not what we expect
         if "server_id" not in discovery_info.properties:
             return self.async_abort(reason="missing_server_id")
-        # abort if we already have exactly this server_id
-        # reload the integration if the host got updated
+        
         self.server_info = ServerInfoMessage.from_dict(discovery_info.properties)
         await self.async_set_unique_id(self.server_info.server_id)
-        self._abort_if_unique_id_configured(
-            updates={CONF_URL: self.server_info.base_url},
-            reload_on_update=True,
-        )
+        
+        # Check if we already have a config entry for this server_id
+        existing_entry = self.hass.config_entries.async_entry_for_domain_unique_id(
+            DOMAIN, self.server_info.server_id)
+        if existing_entry:
+            # Test connectivity to the current URL first
+            current_url = existing_entry.data[CONF_URL]
+            try:
+                await get_server_info(self.hass, current_url)
+                # Current URL is working, no need to update
+                return self.async_abort(reason="already_configured")
+            except CannotConnect:
+                # Current URL is not working, update to the discovered URL
+                # and continue to discovery confirm
+                self.hass.config_entries.async_update_entry(
+                    existing_entry,
+                    data={**existing_entry.data, CONF_URL: self.server_info.base_url},
+                )
+                # Schedule reload since URL changed
+                self.hass.config_entries.async_schedule_reload(existing_entry.entry_id)
+        else:
+            # No existing entry, proceed with normal flow
+            self._abort_if_unique_id_configured()
+
+        # Test connectivity to the discovered URL
         try:
             await get_server_info(self.hass, self.server_info.base_url)
         except CannotConnect:


### PR DESCRIPTION
Previously, the zeroconf discovery flow would automatically update the config entry URL whenever a different URL was discovered for the same server, even if the current URL was still working. This caused unnecessary reloads and potential disruption to the user experience.

## Changes
- Test connectivity to current URL before updating on zeroconf discovery
- Only update URL and schedule reload when current URL is unreachable
- Proceed to discovery confirm step when URL update is needed
- Maintain existing behavior for new server discoveries
- Use user_input[CONF_URL] consistently in async_step_user method

This improves stability by preventing unnecessary URL changes while still providing automatic recovery when the current connection becomes unavailable.

## References
This change is based on improvements from Home Assistant Core PR #152030: https://github.com/home-assistant/core/pull/152030
Related discussion: https://github.com/orgs/music-assistant/discussions/4229